### PR TITLE
Set NODE_ENV into production Dockerfile

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:12-alpine AS builder
 
+ENV NODE_ENV production
+
 WORKDIR /app
 
 COPY package.json /app/package.json
@@ -7,6 +9,8 @@ COPY package.json /app/package.json
 RUN npm install --production
 
 FROM node:12-alpine
+
+ENV NODE_ENV production
 
 WORKDIR /app
 

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "3"
-services:
-  sprite-generator:
-    build:
-      context: ../../
-      dockerfile: docker/production/Dockerfile
-    environment:
-      NODE_ENV: production


### PR DESCRIPTION
**Background**
In production we are using docker w/o docker-compose and I was setting `NODE_ENV` in `docker-compose.yaml` file which resulted that the script was running actually in development environment.

```js
const development = {
  workingDirDestination: `${__dirname}/tmp/`,
  santimentUrl: 'https://api-stage.santiment.net',
  s3Path: AWS_S3_PATH,
  s3Key: AWS_S3_ACCESS_KEY_ID,
  s3Secret: AWS_S3_SECRET_ACCESS_KEY,
  s3Bucket: AWS_S3_BUCKET_NAME,
  s3Region: AWS_S3_BUCKET_REGION
}
```

So it was building a sprite image only with the projects that are in the staging database.

**Implementation** 
Set `NODE_ENV` to production into `docker/production/Dockerfile` and remove `docker-compose.yaml` file.